### PR TITLE
Only allow existing file extensions in updated names

### DIFF
--- a/app/controllers/file_version_memberships_controller.rb
+++ b/app/controllers/file_version_memberships_controller.rb
@@ -13,7 +13,10 @@ class FileVersionMembershipsController < ApplicationController
       end
     else
       respond_to do |format|
-        format.html { render :edit }
+        format.html do
+          flash[:alert] = @file_version.errors.full_messages
+          render :edit
+        end
         format.json { render json: @file_version.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/file_version_membership.rb
+++ b/app/models/file_version_membership.rb
@@ -12,6 +12,8 @@ class FileVersionMembership < ApplicationRecord
               scope: :work_version_id
             }
 
+  validate :filename_extentions_cannot_change
+
   delegate :size, :mime_type, :original_filename, to: :uploader
 
   private
@@ -22,5 +24,11 @@ class FileVersionMembership < ApplicationRecord
 
     def initialize_title
       self.title ||= uploader&.original_filename
+    end
+
+    def filename_extentions_cannot_change
+      return if title.blank? || File.extname(title) == File.extname(original_filename)
+
+      errors[:title] << "does not have the same filename extension as #{original_filename}"
     end
 end

--- a/app/views/file_version_memberships/edit.html.erb
+++ b/app/views/file_version_memberships/edit.html.erb
@@ -1,21 +1,20 @@
 <h1>Editing</h1>
 
+<% if flash.alert %>
+  <div class="alert alert-danger" role="alert">
+    <h2>Errors</h2>
+    <ul>
+      <% flash.alert.each do |alert| %>
+        <li><%= alert %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_with(
       model: @file_version,
       url: work_version_file_path(params[:work_id], params[:version_id], @file_version),
       local: true) do |form| %>
-
-  <% if form.object.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(form.object.errors.count, "error") %> prohibited this file from being saved:</h2>
-
-      <ul>
-        <% form.object.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
 
   <div class="form-group">
     <%= form.label :title %>


### PR DESCRIPTION
Also adds file validation errors to the flash hash. We could repeat this pattern elsewhere have a global template to render any flash-based messages.