### PR TITLE
Filenames can be edited-in-place in File Listing

### DIFF
--- a/app/javascript/controllers/filename_editor_controller.js
+++ b/app/javascript/controllers/filename_editor_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = ['titleStatic', 'form', 'titleField', 'errorsContainer']
+
+  connect() {
+    this.formTarget.style.display = 'none'
+  }
+
+  showForm(event) {
+    event && event.preventDefault()
+    this.titleFieldTarget.value = this.titleStaticTarget.textContent
+    this.formTarget.style.display = ''
+    this.titleStaticTarget.style.display = 'none'
+    this.errorsContainerTarget.style.display = 'none'
+  }
+
+  hideForm(event) {
+    event && event.preventDefault()
+    this.formTarget.style.display = 'none'
+    this.titleStaticTarget.style.display = ''
+  }
+
+  toggleForm(event) {
+    this.formTarget.style.display === 'none' ? this.showForm(event) : this.hideForm(event)
+  }
+
+  onPostSuccess(event) {
+    let [ fileVersionMembership ] = event.detail
+    this.titleStaticTarget.textContent = fileVersionMembership.title
+    this.hideForm()
+  }
+
+  onPostError(event) {
+    let errorsList = this.errorsContainerTarget.querySelector('ul')
+    let [ errors ] = event.detail
+    let errorFullMessages = Object.keys(errors)
+      .map(attribute => [attribute, errors[attribute]] )
+      .flatMap(([attribute, messages]) => {
+        return messages.map(message => `${attribute} ${message}`)
+      })
+
+    this.errorsContainerTarget.style.display = ''
+
+    errorsList.innerHTML = errorFullMessages.map(msg => `<li>${msg}</li>`)
+  }
+}

--- a/app/views/file_lists/edit.html.erb
+++ b/app/views/file_lists/edit.html.erb
@@ -7,14 +7,40 @@
     </thead>
     <tbody>
       <%# TODO move to controller? %>
-      <% file_memberships =  @work_version.file_version_memberships.includes(:file_resource) %>
+      <% file_memberships = @work_version.file_version_memberships.includes(:file_resource) %>
       <% file_memberships.each do |membership| %>
-        <tr id="<%= dom_id membership %>">
-          <td><%= membership.title %></td>
+        <tr id="<%= dom_id membership %>" data-controller="filename-editor">
+          <td>
+            <span data-target="filename-editor.titleStatic"><%= membership.title %></span>
+
+            <%= form_with(
+                  model: membership,
+                  url: work_version_file_path(params[:work_id], params[:version_id], membership),
+                  class: 'form-inline',
+                  html: {
+                    data: {
+                      type: 'json',
+                      action: 'ajax:success->filename-editor#onPostSuccess ' +
+                              'ajax:error->filename-editor#onPostError',
+                      target: 'filename-editor.form'
+                    }
+                  }) do |f| %>
+
+              <%= f.label :title, class: 'sr-only' %>
+              <%= f.text_field :title, class: 'form-control', data: { target: 'filename-editor.titleField' } %>
+              <%= f.submit 'Save', class: 'btn btn-primary', data: { disable_with: 'Saving...' } %>
+              <%= link_to 'Cancel', '#', class: 'btn btn-link', data: { action: 'click->filename-editor#hideForm' } %>
+              <div class="alert alert-danger" role="alert" data-target="filename-editor.errorsContainer">
+                <ul data-target="filename-editor.errors"></ul>
+              </div>
+            <% end %>
+          </td>
           <td><%= number_to_human_size membership.size %></td>
           <td><%= membership.mime_type %></td>
           <td>
-            <%= link_to 'Rename', edit_work_version_file_path(params[:work_id], params[:version_id], membership.id) %> |
+            <%= link_to 'Rename',
+              edit_work_version_file_path(params[:work_id], params[:version_id], membership.id),
+              data: { action: 'click->filename-editor#toggleForm' } %> |
             <%= link_to 'Delete',
                 work_version_file_path(params[:work_id], params[:version_id], membership.id),
                 method: :delete, data: { confirm: 'Are you sure?' } %>


### PR DESCRIPTION
In-place editing of filenames!

Originally I'd done this with a combination of stimulus to toggle the visibility of the form on and off, and Rail's `form_with remote` + SJR `.js` views to handle the response from the update action. I really didn't like the SJR thing and wanted to hit the existing `.json` API that we'd already built instead. But I also wanted to keep `form_with remote` and all the fancy stuff that we get with it (such as auto-disabling the submit button, nice and easy events on successful and unsuccessful request, etc).

I did eventually figure it out, and it wasn't that hard! Basically all you have to do is tell `form_with` that you want to hit the json type instead of the default js type, like so:

```ruby
form_with( model: ..., url: ..., html: { data: { type: 'json' } } )
```

From there it's a matter of hooking everything up with Stimulus. It goes like this:

Happy path:
1. User clicks the "Rename" button, Stimulus shows the form
2. User types a valid filename, hits submit, *Rails UJS* submits the form
3. JSON API endpoint does its thing and returns the updated object as json
4. Rails UJS fires the "great success" callback, which Stimulus is listening for
5. Stimulus reads the JSON response from the API endpoint, and sets the static html display of the filename to whatever's in the JSON response (presumably, what they submitted in the form)
6. Stimulus hides the form

Sad path:
1. User clicks the "Rename" button, Stimulus shows the form
2. User types an invalid filename, hits submit, *Rails UJS* submits the form
3. JSON API endpoint does its thing and returns the list of validation errors as JSON
4. Rails UJS fires the "error" callback, which Stimulus is listening for
5. Stimulus reads the list of errors, builds them into an error message alert thingy just like a form would, and displays that
